### PR TITLE
Use correct class name in @see docblock

### DIFF
--- a/src/Facades/Mailcoach.php
+++ b/src/Facades/Mailcoach.php
@@ -5,7 +5,7 @@ namespace Spatie\MailcoachSdk\Facades;
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @see \Spatie\MailcoachSdk\MailcoachSdk
+ * @see \Spatie\MailcoachSdk\Mailcoach
  */
 class Mailcoach extends Facade
 {


### PR DESCRIPTION
Hey! 😄

This PR is only a small one and just updates the class name in the docblock for the `Mailcoach` facade.

I'm not sure if what I've done is correct, but it seems like my PhpStorm couldn't find a `\Spatie\MailcoachSdk\MailcoachSdk` class, but could find the `\Spatie\MailcoachSdk\Mailcoach` class (which is returned in the facade's `getFacadeAccessor` method). So I've made the assumption that the class name currently being used might be incorrect?

Apologies if what I've done is wrong!