### PR TITLE
Add tags attribute to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ $subscriber = Mailcoach::createSubscriber(
         'email' => '<email-address>',
         'first_name' => 'John',
         'last_name' => 'Doe',
+        'tags' => ['Newsletter'],
     ]);
 ```
 


### PR DESCRIPTION
I couldn't find anything about tags, but the attributes seem to accept a tags attribute, maybe it's useful adding it to the example?